### PR TITLE
Change HibernateMode from "Auto" to "Nvram"

### DIFF
--- a/OC/config.plist
+++ b/OC/config.plist
@@ -1669,7 +1669,7 @@
 		<key>Boot</key>
 		<dict>
 			<key>HibernateMode</key>
-			<string>Auto</string>
+			<string>NVRAM</string>
 			<key>PickerMode</key>
 			<string>External</string>
 			<key>HideAuxiliary</key>


### PR DESCRIPTION
Hey @EETagent,

there is a kind of error in your latest update. `HibernateMode` should be set to `NVRAM` instead of `Auto` as we are blocking out the upper memory bank of the RTC-Memory (80-AB), which is used by OSX for information about hibernation, anyway. The same bank is used and checksummed by Lenovo for diagnostic and internal informations, which led to the CMOS-corruption-errors in first place. So setting this to `Auto` introduces a potential bug and has no value.